### PR TITLE
fix(sdk): Remove use of android id as unique identifier

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -13,14 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v4
+      - uses: gradle/wrapper-validation-action@v3
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: '17'
+          distribution: 'temurin'
       - uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/versions.properties') }}
 
       - name: Run Gradle Tasks
-        run: ./gradlew build check publishToMavenLocal --continue
+        run: ./gradlew build check --continue

--- a/analytics-android/src/main/java/com/reelevant/analytics_android/sdk.kt
+++ b/analytics-android/src/main/java/com/reelevant/analytics_android/sdk.kt
@@ -330,7 +330,7 @@ class ReelevantSDK(private var context: Context, companyId: String, datasourceId
             ReelevantLogger.debug("Unable to collect advertising ID from Amazon Fire OS.")
         }
         ReelevantLogger.debug("Unable to collect advertising ID from Amazon Fire OS and Google Play Services.")
-        return Secure.ANDROID_ID
+        return this.randomIdentifier()
     }
 
     private suspend fun getTemporaryUserId(): String {

--- a/analytics-android/src/test/java/com/reelevant/analytics_android/SendUnitTest.kt
+++ b/analytics-android/src/test/java/com/reelevant/analytics_android/SendUnitTest.kt
@@ -108,8 +108,8 @@ class SendUnitTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun shouldSendEventWithAndroidIdWhenNoSharedPreferences () = runTest {
-        val expected = "{\"eventId\":\"1234567890123456789012345\",\"clientId\":\"UserId\",\"data\":{},\"v\":1,\"tmpId\":\"android_id\",\"name\":\"page_view\",\"key\":\"dummy-company-id\",\"url\":\"unknown\",\"timestamp\":123456789876543}"
+    fun shouldSendEventWithRandomIdWhenNoSharedPreferences () = runTest {
+        val expected = "{\"eventId\":\"1234567890123456789012345\",\"clientId\":\"UserId\",\"data\":{},\"v\":1,\"tmpId\":\"1234567890123456789012345\",\"name\":\"page_view\",\"key\":\"dummy-company-id\",\"url\":\"unknown\",\"timestamp\":123456789876543}"
         val event = sdk.pageView(emptyMap())
 
         every { sharedPreferences.getString(ReelevantAnalytics.TEMPORARY_USER_ID, null) } returns null

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,6 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
-    implementation("com.reelevant.analytics:analytics-android:0.0.2-SNAPSHOT")
+    implementation(project(":analytics-android"))
     implementation(libs.gms.play.services.ads)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 # Maven settings:
-VERSION_NAME=0.0.2-SNAPSHOT
+VERSION_NAME=0.0.3-SNAPSHOT
 GROUP=com.reelevant.analytics
 ARTIFACT=analytics-android
 POM_NAME=Reelevant Android Analytics


### PR DESCRIPTION
I choose to remove the use of ANDROID_ID to follow the recommandation and the real use.

First, ANDROID_ID is always returning a constant, but is a mean to fetch the real unique ID.
(cf https://stackoverflow.com/questions/26244512/android-provider-settings-secure-android-id-returns-android-id)

By using the solution on this stackoverflow post, we have a warning cause the use of this method is not recommanded.
We should follow this documentation:
https://developer.android.com/identity/user-data-ids

And that is already done by using the google or amazon advertising ID.
So the fallback, if the client don't implement either of those library, is to generate a random string and store it.